### PR TITLE
PHP 8.1 deprecation when required parameter is after optional parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build.sh
 *.zip
 *~
 samples/
+.DS_Store

--- a/src/Browshot.php
+++ b/src/Browshot.php
@@ -25,7 +25,7 @@ class Browshot
 {
 	const version = '1.29.0';
 
-	public string _$key;
+	public string $_key;
 	public int $_base
 	public string $_debug;
 

--- a/src/Browshot.php
+++ b/src/Browshot.php
@@ -26,8 +26,8 @@ class Browshot
 	const version = '1.29.0';
 
 	public string $_key;
-	public int $_base
-	public string $_debug;
+	public string $_base;
+	public int $_debug;
 
 	/**
 	 * Constructor

--- a/src/Browshot.php
+++ b/src/Browshot.php
@@ -25,6 +25,10 @@ class Browshot
 {
 	const version = '1.29.0';
 
+	public string _$key;
+	public int $_base
+	public string $_debug;
+
 	/**
 	 * Constructor
 	 *

--- a/src/Browshot.php
+++ b/src/Browshot.php
@@ -327,7 +327,7 @@ class Browshot
      * @param int   screenshot ID
      * @param array
      *
-     * @return string Return an empty string if the image could not be retrieved, otherwise return the PNG content.
+     * @return mixed Return an error array if the ID is empty, empty string if the image could not be retrieved, otherwise return the PNG content.
      */
 	public function screenshot_thumbnail($id = 0, $parameters = array())
 	{
@@ -361,9 +361,9 @@ class Browshot
 		* @param string file name
 		* @param array
 		*
-		* @return string Return an empty string if the image could not be retrieved or saved, otherwise return the file name.
+		* @return mixed Return an error array if the ID or file is empty, an empty string if the image could not be retrieved or saved, otherwise return the file name.
 		*/
-	public function screenshot_thumbnail_file($id = 0, $file, $parameters = array())
+	public function screenshot_thumbnail_file($id = 0, $file = '', $parameters = array())
 	{
 		if ($file == '') {
 			$this->error("Missing file in screenshot_thumbnail_file");
@@ -671,5 +671,3 @@ class Browshot
 		return $result;
 	}
 }
-
-?>


### PR DESCRIPTION
- In PHP 8.1, this package results in a deprecation as the function `screenshot_thumbnail_file` uses an optional parameter (`$id`) before a required parameter (`$file`). By passing a default value to the `$file` parameter, we're able to resolve this deprecation.
- Also fixes an IDE warning where the `@return` type was string, but `generic_error` returned an array, so it's possible for mixed type returns in these functions.
- Also removes the whitespace and PHP tag at end of file (no longer required).
- Adds .DS_Store to .gitignore